### PR TITLE
Fix typo @router to @Router

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ This comments is most important for swagger UI generation. Please, see example b
     // @Param   created_to      query   string  false        "Date-time string, MySQL format. If specified, API will retrieve orders that were created before created_to"
     // @Success 200 {array}  my_api.model.OrderRow
     // @Failure 400 {object} my_api.ErrorResponse    Customer ID must be specified
-    // @router /orders/by-customer/{customer_id} [get]
+    // @Router /orders/by-customer/{customer_id} [get]
 
 Lets describe every line in details:  
 * @Title comment is "nickname" in swagger terms. Kind of "alias" for this API operation. Only [a-Z0-9] characters are allowed.  Its used only in automatic swagger client generators
@@ -68,8 +68,8 @@ Lets describe every line in details:
  * response_type - can be {object} or {array} - if your method return array of elements
  * response_data_type - data type of your response. Can be one of Go build in types, or your custom type. All interface types will be displayed just as "interface". Its not possible to find out which type it will has at parsing time.  
  * response_description - optional. Usually make sense only for error responses
-* @router - define route path, which should be used to call this API operation. It has following format:  
- @router request_path [request_method]    
+* @Router - define route path, which should be used to call this API operation. It has following format:  
+ @Router request_path [request_method]    
  * reqiest_path which should be used by to make request to this API endpoint. It can include placeholders for parameters with transport type equal "path". Look at the example above. 
  * request_method - just HTTP request method (get/post/etc..)
  

--- a/example/api.go
+++ b/example/api.go
@@ -23,7 +23,7 @@ func (c *Context) WriteResponse(response interface{}) {
 // @Success 200 {object} string
 // @Failure 400 {object} APIError "We need ID!!"
 // @Failure 404 {object} APIError "Can not find ID"
-// @router /testapi/get-string-by-int/{some_id} [get]
+// @Router /testapi/get-string-by-int/{some_id} [get]
 func (c *Context) GetStringByInt(rw web.ResponseWriter, req *web.Request) {
 	c.WriteResponse(fmt.Sprint("Some data for %s ID", req.PathParams["some_id"]))
 }
@@ -37,7 +37,7 @@ func (c *Context) GetStringByInt(rw web.ResponseWriter, req *web.Request) {
 // @Success 200 {object} StructureWithEmbededStructure
 // @Failure 400 {object} APIError "We need ID!!"
 // @Failure 404 {object} APIError "Can not find ID"
-// @router /testapi/get-struct-by-int/{some_id} [get]
+// @Router /testapi/get-struct-by-int/{some_id} [get]
 func (c *Context) GetStructByInt(rw web.ResponseWriter, req *web.Request) {
 	c.WriteResponse(StructureWithEmbededStructure{})
 }
@@ -51,7 +51,7 @@ func (c *Context) GetStructByInt(rw web.ResponseWriter, req *web.Request) {
 // @Success 200 {object} StructureWithEmbededPointer
 // @Failure 400 {object} APIError "We need ID!!"
 // @Failure 404 {object} APIError "Can not find ID"
-// @router /testapi/get-struct2-by-int/{some_id} [get]
+// @Router /testapi/get-struct2-by-int/{some_id} [get]
 func (c *Context) GetStruct2ByInt(rw web.ResponseWriter, req *web.Request) {
 	c.WriteResponse(StructureWithEmbededPointer{})
 }
@@ -65,7 +65,7 @@ func (c *Context) GetStruct2ByInt(rw web.ResponseWriter, req *web.Request) {
 // @Success 200 {array} string
 // @Failure 400 {object} APIError "We need ID!!"
 // @Failure 404 {object} APIError "Can not find ID"
-// @router /testapi/get-simple-array-by-string/{some_id} [get]
+// @Router /testapi/get-simple-array-by-string/{some_id} [get]
 func (c *Context) GetSimpleArrayByString(rw web.ResponseWriter, req *web.Request) {
 	c.WriteResponse([]string{"one", "two", "three"})
 }
@@ -79,7 +79,7 @@ func (c *Context) GetSimpleArrayByString(rw web.ResponseWriter, req *web.Request
 // @Success 200 {array} SimpleStructureWithAnnotations
 // @Failure 400 {object} APIError "We need ID!!"
 // @Failure 404 {object} APIError "Can not find ID"
-// @router /testapi/get-struct-array-by-string/{some_id} [get]
+// @Router /testapi/get-struct-array-by-string/{some_id} [get]
 func (c *Context) GetStructArrayByString(rw web.ResponseWriter, req *web.Request) {
 	c.WriteResponse([]subpackage.SimpleStructure{
 		subpackage.SimpleStructure{},
@@ -94,7 +94,7 @@ func (c *Context) GetStructArrayByString(rw web.ResponseWriter, req *web.Request
 // @Success 200 {object} InterfaceType
 // @Failure 400 {object} APIError "We need ID!!"
 // @Failure 404 {object} APIError "Can not find ID"
-// @router /testapi/get-interface [get]
+// @Router /testapi/get-interface [get]
 func (c *Context) GetInterface(rw web.ResponseWriter, req *web.Request) {
 	c.WriteResponse(InterfaceType("Some string"))
 }
@@ -105,7 +105,7 @@ func (c *Context) GetInterface(rw web.ResponseWriter, req *web.Request) {
 // @Success 200 {object} SimpleAlias
 // @Failure 400 {object} APIError "We need ID!!"
 // @Failure 404 {object} APIError "Can not find ID"
-// @router /testapi/get-simple-aliased [get]
+// @Router /testapi/get-simple-aliased [get]
 func (c *Context) GetSimpleAliased(rw web.ResponseWriter, req *web.Request) {
 	c.WriteResponse("Some string")
 }
@@ -116,7 +116,7 @@ func (c *Context) GetSimpleAliased(rw web.ResponseWriter, req *web.Request) {
 // @Success 200 {array} InterfaceType
 // @Failure 400 {object} APIError "We need ID!!"
 // @Failure 404 {object} APIError "Can not find ID"
-// @router /testapi/get-array-of-interfaces [get]
+// @Router /testapi/get-array-of-interfaces [get]
 func (c *Context) GetArrayOfInterfaces(rw web.ResponseWriter, req *web.Request) {
 	c.WriteResponse([]InterfaceType{"Some string", 123, "10"})
 }
@@ -127,7 +127,7 @@ func (c *Context) GetArrayOfInterfaces(rw web.ResponseWriter, req *web.Request) 
 // @Success 200 {object} StructureWithSlice
 // @Failure 400 {object} APIError "We need ID!!"
 // @Failure 404 {object} APIError "Can not find ID"
-// @router /testapi/get-struct3 [get]
+// @Router /testapi/get-struct3 [get]
 func (c *Context) GetStruct3(rw web.ResponseWriter, req *web.Request) {
 	c.WriteResponse(StructureWithSlice{})
 }

--- a/parser/operation.go
+++ b/parser/operation.go
@@ -51,7 +51,7 @@ func (operation *Operation) SetItemsType(itemsType string) {
 
 func (operation *Operation) ParseComment(comment string) error {
 	commentLine := strings.TrimSpace(strings.TrimLeft(comment, "//"))
-	if strings.HasPrefix(commentLine, "@router") {
+	if strings.HasPrefix(commentLine, "@Router") {
 		if err := operation.ParseRouterComment(commentLine); err != nil {
 			return err
 		}
@@ -148,9 +148,9 @@ func (operation *Operation) ParseAcceptComment(commentLine string) error {
 	return nil
 }
 
-// @router /customer/get-wishlist/{wishlist_id} [get]
+// @Router /customer/get-wishlist/{wishlist_id} [get]
 func (operation *Operation) ParseRouterComment(commentLine string) error {
-	sourceString := strings.TrimSpace(commentLine[len("@router"):])
+	sourceString := strings.TrimSpace(commentLine[len("@Router"):])
 
 	re := regexp.MustCompile(`([\w\.\/\-{}]+)[^\[]+\[([^\]]+)`)
 	var matches []string

--- a/parser/operation_test.go
+++ b/parser/operation_test.go
@@ -49,13 +49,13 @@ func (suite *OperationSuite) TestParseAcceptComment() {
 
 func (suite *OperationSuite) TestParseRouterComment() {
 	op := parser.NewOperation(suite.parser, "test")
-	err := op.ParseRouterComment("@router /customer/get-wishlist/ [get]")
+	err := op.ParseRouterComment("@Router /customer/get-wishlist/ [get]")
 	assert.Nil(suite.T(), err, "Can not parse router comment")
 	assert.Equal(suite.T(), op.Path, "/customer/get-wishlist/", "Can not parse router comment")
 	assert.Equal(suite.T(), op.HttpMethod, "GET", "Can not parse router comment")
 
 	op2 := parser.NewOperation(suite.parser, "test")
-	err2 := op2.ParseRouterComment("@router /customer/get-wishlist/{id} [PoSt]")
+	err2 := op2.ParseRouterComment("@Router /customer/get-wishlist/{id} [PoSt]")
 	assert.Nil(suite.T(), err2, "Can not parse router comment")
 	assert.Equal(suite.T(), op2.Path, "/customer/get-wishlist/{id}", "Can not parse router comment")
 	assert.Equal(suite.T(), op2.HttpMethod, "POST", "Can not parse router comment")
@@ -113,7 +113,7 @@ func (suite *OperationSuite) TestParseComment() {
 // @Param   order_nr     path    string  true	"Order number"
 // @Success 200 {array}  int
 // @Failure 400 {simple} string     "Order ID must be specified"
-// @router order/by-number/{order_nr} [get]
+// @Router order/by-number/{order_nr} [get]
 `
 	op := parser.NewOperation(suite.parser, "test")
 	for _, line := range strings.Split(operationComment, "\n") {


### PR DESCRIPTION
Maintaining the same notation as other parameters.
