### PR TITLE
Fixed the parser for "@Success" and "@Failure"...

### DIFF
--- a/parser/operation.go
+++ b/parser/operation.go
@@ -166,7 +166,7 @@ func (operation *Operation) ParseRouterComment(commentLine string) error {
 
 // @Success 200 {object} model.OrderRow "Error message, if code != 200"
 func (operation *Operation) ParseResponseComment(commentLine string) error {
-	re := regexp.MustCompile(`([\d]+)[\s]+([\w\{\}]+)[\s]+([\w\.\/]+)[^"]*(.*)?`)
+	re := regexp.MustCompile(`([\d]+)[\s]+([\w\{\}]+)[\s]+([\w\-\.\/]+)[^"]*(.*)?`)
 	var matches []string
 
 	if matches = re.FindStringSubmatch(commentLine); len(matches) != 5 {


### PR DESCRIPTION
... to allow hyphens in the model names. (Issue #7)
