### PR TITLE
If the mainApiFile command-line switch is left blank, then ...

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -78,7 +78,11 @@ func InitParser() *parser.Parser {
 
 func main() {
 	flag.Parse()
-	if *apiPackage == "" || *mainApiFile == "" {
+
+	if *mainApiFile == "" {
+		*mainApiFile = *apiPackage + "/main.go"
+	}
+	if *apiPackage == "" {
 		flag.PrintDefaults()
 		return
 	}


### PR DESCRIPTION
...main.go is assumed (in the location specified by apiPackage). (No issue number.)
