### PR TITLE
An optional "@Resource name" annotation ... (Issue #3)

### DIFF
--- a/parser/operation.go
+++ b/parser/operation.go
@@ -23,6 +23,7 @@ type Operation struct {
 	Authorizations   []Authorization   `json:"authorizations,omitempty"`
 	Protocols        []Protocol        `json:"protocols,omitempty"`
 	Path             string            `json:"-"`
+	ForceResource    string
 	parser           *Parser
 	Models           []*Model `json:"-"`
 	packageName      string
@@ -55,6 +56,12 @@ func (operation *Operation) ParseComment(comment string) error {
 		if err := operation.ParseRouterComment(commentLine); err != nil {
 			return err
 		}
+	} else if strings.HasPrefix(commentLine, "@Resource") {
+		resource := strings.TrimSpace(commentLine[len("@Resource"):])
+		if resource[0:1] == "/" {
+			resource = resource[1:]
+		}
+		operation.ForceResource = resource
 	} else if strings.HasPrefix(commentLine, "@Title") {
 		operation.Nickname = strings.TrimSpace(commentLine[len("@Title"):])
 	} else if strings.HasPrefix(commentLine, "@Description") {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -165,16 +165,21 @@ func (parser *Parser) AddOperation(op *Operation) {
 		}
 	}
 
-	api, ok := parser.TopLevelApis[path[0]]
+	resource := path[0]
+	if op.ForceResource != "" {
+		resource = op.ForceResource
+	}
+
+	api, ok := parser.TopLevelApis[resource]
 	if !ok {
 		api = NewApiDeclaration()
 
 		api.ApiVersion = parser.Listing.ApiVersion
 		api.SwaggerVersion = SwaggerVersion
-		api.ResourcePath = "/" + path[0]
+		api.ResourcePath = "/" + resource
 		api.BasePath = parser.BasePath
 
-		parser.TopLevelApis[path[0]] = api
+		parser.TopLevelApis[resource] = api
 
 		apiRef := &ApiRef{
 			Path:        api.ResourcePath,


### PR DESCRIPTION
...can be used to force the resource identifier to be something other than the first segment of the route URI. For example, if "@Resource /payment" is specified together with "@Router /invoice/{id}/payments [get]" then this operation will be part of the "payment" sub-api, rather than the "invoice" sub-api. This is also good for when the @Router specifies a path in which the first segment is almost correct, but not quite, e.g. /payments (plural) vs. /payment (singular). A leading slash in the name in the @Resource annotation is optional. So, "@Resource /payment" and "@Resource payment" are the same. (Issue #3)
