### PR TITLE
Correction. An "error" response type is now simply passed along as "error" (not string).

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Let's discuss every line in detail:
  @Success http_response_code response_type response_data_type response_description
  * http_response_code 200 for success response, any other code for failure.
  * response_type - can be {object} or {array} -- depending on whether the operation returns a single JSON object, or an array of objects
- * response_data_type - data type of your response. Can be one of the Go built-in types (including error), or your custom type. All interface types will be displayed just as "interface". (It's not possible to find out which type it will has at parsing time.) Note: Technically, "error" is not a built-in type, but it's allowed here as a synonym for "string".
+ * response_data_type - data type of your response. Can be one of the Go built-in types, including error (which is actually a built-in interface, not a built-in type), or your custom type. All interface types except "error" will be displayed just as "interface". (It's not possible to find out which type it will has at parsing time.)
  * response_description - optional. It usually only makes sense for error responses.
 * @Router - define route path, which should be used to call this API operation. It has the following format:
  @Router request_path [request_method]

--- a/parser/operation.go
+++ b/parser/operation.go
@@ -189,9 +189,7 @@ func (operation *Operation) ParseResponseComment(commentLine string) error {
 	response.Message = strings.Trim(matches[4], "\"")
 
 	typeName := ""
-	if matches[3] == "error" {
-		typeName = "string"
-	} else if IsBasicType(matches[3]) {
+	if matches[3] == "error" || IsBasicType(matches[3]) {
 		typeName = matches[3]
 	} else {
 		model := NewModel(operation.parser)


### PR DESCRIPTION
Oops, again.  You were too fast for me. I found more to change.  :-)
