### PR TITLE
For any direct-equivalency type definitions (i.e. non-struct, e.g. "type foo string"), ...

### DIFF
--- a/parser/operation.go
+++ b/parser/operation.go
@@ -112,14 +112,20 @@ func (operation *Operation) getUniqueModels() []*Model {
 func (operation *Operation) registerType(typeName string) (string, error) {
 	registerType := ""
 
-	if IsBasicType(typeName) {
+	if translation, ok := typeDefTranslations[typeName]; ok {
+		registerType = translation
+	} else if IsBasicType(typeName) {
 		registerType = typeName
 	} else {
 		model := NewModel(operation.parser)
 		knownModelNames := map[string]bool{}
 
-		if err, innerModels := model.ParseModel(typeName, operation.parser.CurrentPackage, knownModelNames); err != nil {
+		err, innerModels := model.ParseModel(typeName, operation.parser.CurrentPackage, knownModelNames)
+		if err != nil {
 			return registerType, err
+		}
+		if translation, ok := typeDefTranslations[typeName]; ok {
+			registerType = translation
 		} else {
 			registerType = model.Id
 


### PR DESCRIPTION
... any references to the defined type (foo) will be replaced with the underlying type (string) at parse-time, as if the annotation referred to the underlying type (string) all along. This prevents the model section from being cluttered with empty (foo) definitions.
