### PR TITLE
Required keyword

### DIFF
--- a/markup/markup.go
+++ b/markup/markup.go
@@ -11,6 +11,19 @@ import (
 	"strings"
 )
 
+const (
+	color_NORMAL_TEXT             = "black"
+	color_API_SECTION_HEADER_TEXT = "red"
+	color_MODEL_TEXT              = "orange"
+	color_NORMAL_BACKGROUND       = "white"
+	color_GET                     = "cyan"
+	color_POST                    = "green"
+	color_PUT                     = "orange"
+	color_DELETE                  = "cyan"
+	color_PATCH                   = "purple"
+	color_DEFAULT                 = "yellow"
+)
+
 type Markup interface {
 	sectionHeader(level int, text string) string
 	bulletedItem(level int, text string) string
@@ -21,6 +34,7 @@ type Markup interface {
 	tableHeaderRow(args ...string) string
 	tableRow(args ...string) string
 	tableFooter() string
+	colorSpan(content, foregroundColor, backgroundColor string) string
 }
 
 func GenerateMarkup(parser *parser.Parser, markup Markup, outputSpec *string, defaultFileExtension string) {
@@ -61,7 +75,7 @@ func GenerateMarkup(parser *parser.Parser, markup Markup, outputSpec *string, de
 		* Sub-API Specifications
 		***************************************************************/
 		buf.WriteString(markup.anchor(apiKey))
-		buf.WriteString(markup.sectionHeader(2, apiKey))
+		buf.WriteString(markup.sectionHeader(2, markup.colorSpan(apiKey, color_API_SECTION_HEADER_TEXT, color_NORMAL_BACKGROUND)))
 
 		buf.WriteString(markup.tableHeader(""))
 		buf.WriteString(markup.tableHeaderRow("Specification", "Value"))
@@ -98,7 +112,7 @@ func GenerateMarkup(parser *parser.Parser, markup Markup, outputSpec *string, de
 				buf.WriteString("\n")
 				operationString := fmt.Sprintf("%s (%s)", strings.Replace(strings.Replace(subapi.Path, "{", "\\{", -1), "}", "\\}", -1), op.HttpMethod)
 				buf.WriteString(markup.anchor(op.Nickname))
-				buf.WriteString(markup.sectionHeader(4, "API: "+operationString))
+				buf.WriteString(markup.sectionHeader(4, markup.colorSpan("API: "+operationString, color_NORMAL_TEXT, operationColor(op.HttpMethod))))
 				buf.WriteString("\n\n" + op.Summary + "\n\n\n")
 
 				if len(op.Parameters) > 0 {
@@ -136,7 +150,7 @@ func GenerateMarkup(parser *parser.Parser, markup Markup, outputSpec *string, de
 		for _, modelKey := range alphabeticalKeysOfModels(apiDescription.Models) {
 			model := apiDescription.Models[modelKey]
 			buf.WriteString(markup.anchor(modelKey))
-			buf.WriteString(markup.sectionHeader(4, shortModelName(modelKey)))
+			buf.WriteString(markup.sectionHeader(4, markup.colorSpan(shortModelName(modelKey), color_MODEL_TEXT, color_NORMAL_BACKGROUND)))
 			buf.WriteString(markup.tableHeader(""))
 			buf.WriteString(markup.tableHeaderRow("Field Name (alphabetical)", "Field Type", "Description"))
 			for _, fieldName := range alphabeticalKeysOfFields(model.Properties) {
@@ -206,4 +220,21 @@ func alphabeticalKeysOfFields(m map[string]*parser.ModelProperty) []string {
 	}
 	sort.Strings(keys)
 	return keys
+}
+
+func operationColor(methodName string) string {
+	switch methodName {
+	case "GET":
+		return color_GET
+	case "POST":
+		return color_POST
+	case "PUT":
+		return color_PUT
+	case "DELETE":
+		return color_DELETE
+	case "PATCH":
+		return color_PATCH
+	default:
+		return color_DEFAULT
+	}
 }

--- a/markup/markup_asciidoc.go
+++ b/markup/markup_asciidoc.go
@@ -67,3 +67,7 @@ func (this *MarkupAsciiDoc) tableRow(args ...string) string {
 	}
 	return retval + "\n"
 }
+
+func (this *MarkupAsciiDoc) colorSpan(content, foregroundColor, backgroundColor string) string {
+	return fmt.Sprintf("[%s,%s-background]#%s#", foregroundColor, backgroundColor, content)
+}

--- a/markup/markup_confluence.go
+++ b/markup/markup_confluence.go
@@ -63,3 +63,17 @@ func (this *MarkupConfluence) tableRow(args ...string) string {
 	}
 	return retval + "|\n"
 }
+
+func (this *MarkupConfluence) colorSpan(content, foregroundColor, backgroundColor string) string {
+	if foregroundColor == "black" && backgroundColor == "white" {
+		return content
+	}
+	if foregroundColor == "black" {
+		return fmt.Sprintf("{bgcolor:%s}%s{bgcolor}", backgroundColor, content)
+	}
+	if backgroundColor == "white" {
+		return fmt.Sprintf("{color:%s}%s{color}", foregroundColor, content)
+	}
+	return fmt.Sprintf("{color:%s}{bgcolor:%s}%s{bgcolor}{color}", foregroundColor, backgroundColor, content)
+
+}

--- a/markup/markup_markdown.go
+++ b/markup/markup_markdown.go
@@ -65,3 +65,8 @@ func (this *MarkupMarkDown) tableRow(args ...string) string {
 func (this *MarkupMarkDown) tableFooter() string {
 	return "\n"
 }
+
+// Note: Github flavored markdown does not support colorization
+func (this *MarkupMarkDown) colorSpan(content, foregroundColor, backgroundColor string) string {
+	return content
+}

--- a/parser/operation.go
+++ b/parser/operation.go
@@ -144,7 +144,7 @@ func (operation *Operation) ParseParamComment(commentLine string) error {
 	swaggerParameter := Parameter{}
 	paramString := strings.TrimSpace(commentLine[len("@Param "):])
 
-	re := regexp.MustCompile(`([\w]+)[\s]+([\w]+)[\s]+([\w.]+)[\s]+([\w]+)[\s]+"([^"]+)"`)
+	re := regexp.MustCompile(`([-\w]+)[\s]+([\w]+)[\s]+([\w.]+)[\s]+([\w]+)[\s]+"([^"]+)"`)
 
 	if matches := re.FindStringSubmatch(paramString); len(matches) != 6 {
 		return fmt.Errorf("Can not parse param comment \"%s\", skipped.", paramString)
@@ -158,7 +158,8 @@ func (operation *Operation) ParseParamComment(commentLine string) error {
 		swaggerParameter.ParamType = matches[2]
 		swaggerParameter.Type = typeName
 		swaggerParameter.DataType = typeName
-		swaggerParameter.Required = strings.ToLower(matches[4]) == "true"
+		requiredText := strings.ToLower(matches[4])
+		swaggerParameter.Required = (requiredText == "true" || requiredText == "required")
 		swaggerParameter.Description = matches[5]
 
 		operation.Parameters = append(operation.Parameters, swaggerParameter)


### PR DESCRIPTION
1. Fixed the Param parser to allow dashes in the parameter name (especially important for describing headers). 2. The 4th column of a Param line that determines whether or not the parameter is required previously only accepted "true" (with anything else being false). It now accepts "true" or "required". Thus, it is now recommended to use "required"/"optional" instead of "true"/"false".