### PR TITLE
Update parser.go

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -124,7 +124,7 @@ func (parser *Parser) CheckRealPackagePath(packagePath string) string {
 		if goroot == "" {
 			log.Fatalf("Please, set $GOROOT environment variable\n")
 		}
-		if evalutedPath, err := filepath.EvalSymlinks(filepath.Join(goroot, "src", "pkg", packagePath)); err == nil {
+		if evalutedPath, err := filepath.EvalSymlinks(filepath.Join(goroot, "src", packagePath)); err == nil {
 			if _, err := os.Stat(evalutedPath); err == nil {
 				pkgRealpath = evalutedPath
 			}


### PR DESCRIPTION
Remove "pkg" in checking the for the real Go root path because directory isn't located under "src". it's under $GOROOT.

Generator complained not finding packages in $GOROOT. This should fix it.
