### PR TITLE
When models have relations, they parse inner model infinitely.

### DIFF
--- a/parser/model.go
+++ b/parser/model.go
@@ -283,6 +283,11 @@ func (p *ModelProperty) GetTypeAsString(fieldType interface{}) string {
 		} else {
 			//			log.Printf("Get type as string(no star expression)! %#v , type: %s\n", fieldType, fmt.Sprint(fieldType))
 			realType = fmt.Sprint(fieldType)
+			relationRegex, _ := regexp.Compile("^[A-Z].*")
+                        if relationRegex.MatchString(realType) {
+                                realType = "interface"
+                        }
+
 		}
 	}
 	return realType


### PR DESCRIPTION
When models have relations, they parse inner model infinitely.
It changes type as interface when the model name starts with capital letter.
