### PR TITLE
FIX parser fails on empty comments

### DIFF
--- a/parser/operation.go
+++ b/parser/operation.go
@@ -52,6 +52,9 @@ func (operation *Operation) SetItemsType(itemsType string) {
 
 func (operation *Operation) ParseComment(comment string) error {
 	commentLine := strings.TrimSpace(strings.TrimLeft(comment, "//"))
+	if !strings.HasPrefix(commentLine, "@") {
+		return nil
+	}
 	attribute := strings.Fields(commentLine)[0]
 	switch strings.ToLower(attribute) {
 	case "@router":


### PR DESCRIPTION
I hope that's the right place, I just hacked the src without looking into it in more detail.
I always got the following error:

2015/03/23 14:37:50 Start parsing
panic: runtime error: index out of range

goroutine 1 [running]:
github.com/yvasiyarov/swagger/parser.(*Operation).ParseComment(0xc20d4cdce0, 0xc208034bd8, 0x2, 0x0, 0x0)
        /home/sszuecs/go/src/github.com/yvasiyarov/swagger/parser/operation.go:56 +0xc59
github.com/yvasiyarov/swagger/parser.(*Parser).ParseApiDescription(0xc208054060, 0x7fffb93e3a06, 0x1b)
        /home/sszuecs/go/src/github.com/yvasiyarov/swagger/parser/parser.go:414 +0x4a8
github.com/yvasiyarov/swagger/parser.(*Parser).ParseApi(0xc208054060, 0x7fffb93e3a06, 0x1b)
        /home/sszuecs/go/src/github.com/yvasiyarov/swagger/parser/parser.go:222 +0x1f4
main.main()
        /home/sszuecs/go/src/github.com/yvasiyarov/swagger/generator.go:155 +0x69e
