### PR TITLE
Replaces hard-coded basePath with one provided on the swagger executa…

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -5,14 +5,15 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"github.com/yvasiyarov/swagger/markup"
-	"github.com/yvasiyarov/swagger/parser"
 	"go/ast"
 	"log"
 	"os"
 	"path"
 	"regexp"
 	"strings"
+
+	"github.com/yvasiyarov/swagger/markup"
+	"github.com/yvasiyarov/swagger/parser"
 )
 
 const (
@@ -21,7 +22,6 @@ const (
 
 var apiPackage = flag.String("apiPackage", "", "The package that implements the API controllers, relative to $GOPATH/src")
 var mainApiFile = flag.String("mainApiFile", "", "The file that contains the general API annotations, relative to $GOPATH/src")
-var basePath = flag.String("basePath", "http://127.0.0.1:3000", "Web service base path")
 var outputFormat = flag.String("format", "go", "Output format type for the generated files: "+AVAILABLE_FORMATS)
 var outputSpec = flag.String("output", "", "Output (path) for the generated file(s)")
 var controllerClass = flag.String("controllerClass", "", "Speed up parsing by specifying which receiver objects have the controller methods")
@@ -106,7 +106,7 @@ func generateSwaggerUiFiles(parser *parser.Parser) {
 func InitParser() *parser.Parser {
 	parser := parser.NewParser()
 
-	parser.BasePath = *basePath
+	parser.BasePath = "{{.}}"
 	parser.IsController = IsController
 
 	parser.TypesImplementingMarshalInterface["NullString"] = "string"

--- a/web.go-example
+++ b/web.go-example
@@ -2,15 +2,20 @@ package main
 
 import (
 	"flag"
+	"os"
 	//	"fmt"
-	"log"
 	"net/http"
 	"strings"
+	"text/template"
+
+	"github.com/fvbock/endless"
+	log "github.com/mgutz/logxi/v1"
 )
 
 var host = flag.String("host", "0.0.0.0", "Host")
 var port = flag.String("port", "8080", "Port")
 var staticContent = flag.String("staticPath", "./swagger-ui", "Path to folder with Swagger UI")
+var apiurl = flag.String("api", "http://127.0.0.1", "The base path URI of the API service")
 
 func IndexHandler(w http.ResponseWriter, r *http.Request) {
 	isJsonRequest := false
@@ -35,7 +40,12 @@ func ApiDescriptionHandler(w http.ResponseWriter, r *http.Request) {
 	apiKey := strings.Trim(r.RequestURI, "/")
 
 	if json, ok := apiDescriptionsJson[apiKey]; ok {
-		w.Write([]byte(json))
+		t, e := template.New("desc").Parse(json)
+		if e != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		t.Execute(w, *apiurl)
 	} else {
 		w.WriteHeader(http.StatusNotFound)
 	}
@@ -55,8 +65,12 @@ func main() {
 	}
 
 	listenTo := *host + ":" + *port
-	log.Printf("Star listen to %s", listenTo)
+	log.Info("Star listen to %s", listenTo)
 
-	http.ListenAndServe(listenTo, http.DefaultServeMux)
-	//http.ListenAndServe(":8080", http.StripPrefix("/swagger-ui/", http.FileServer(http.Dir("./swagger-ui"))))
+	err := endless.ListenAndServe(listenTo, http.DefaultServeMux)
+	if err != nil {
+		log.Error(err.Error())
+	}
+	log.Info("Server on %s stopped", listenTo)
+	os.Exit(0)
 }


### PR DESCRIPTION
Hi,

This change allows generated, committed swagger code to:

1. have a runtime-configurable basePath: same code can be run in multiple environments, supporting staged release process and horizontal scaling with the same binary.  This is the main reason for the change.
2. the sample web.go uses github.com/mgutz/logxi/v1, which is an (almost) drop-in replacement for log.  You may want to revert this, and it isn't necessary, but it does (again) allow for better runtime configuration of logging, and thereby better compliance with 12-Factor philosophy.
3. the sample web.go also uses github.com/fvbock/endless, which _is_ a drop-in replacement for ListenAndServer and provides zero-downtime hot restarts.  Again, you can keep or drop this change, but I'd recommend keeping it despite it not being required for the main purpose of the patch.

Thanks for working on swagger; I really didn't have time to rewrite sashay to be Swagger 2.0 compliant, I'm really pleased that you've written swagger, and I'm getting a lot of use out of it.