### PR TITLE
Documentation fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,26 +37,19 @@ The main difference between this tool and Beego is that this generator doesn't d
 3. Run the Swagger generator.
     Be in the folder with your annotated API source code and run the swagger binary:
 
-    `./$GOPATH/bin/swagger -apiPackage="my_cool_api" -mainApiFile="my_cool_api/web/main.go" -basePath="http://127.0.0.1:3000"`
+    `./$GOPATH/bin/swagger -apiPackage="my_cool_api" -mainApiFile="my_cool_api/web/main.go"`
 
     Command line switches are:
     * **-apiPackage**  - package with API controllers implementation
     * **-mainApiFile** - main API file. We will look for "General API info" in this file. If the mainApiFile command-line switch is left blank, then main.go is assumed (in the location specified by apiPackage).
-    * **-basePath**     - Your API URL. Test requests will be sent to this URL
     * **-format**       - One of: go|swagger|asciidoc|markdown|confluence. Default is -format="go". See below.
     * **-output**       - Output specification. Default varies according to -format. See below.
     * **-controllerClass**  - Speed up parsing by specifying which receiver objects have the controller methods. The default is to search all methods. The argument can be a regular expression. For example, `-controllerClass="(Context|Controller)$"` means the receiver name must end in Context or Controller.
 
- [**You can Generate different formats** ](https://github.com/yvasiyarov/swagger/wiki/Generate-Different-Formats) 
-   
+ [**You can Generate different formats** ](https://github.com/yvasiyarov/swagger/wiki/Generate-Different-Formats)
+
    <br>
 
 4. To run the generated swagger UI (assuming you used -format="go"), copy/move the generated docs.go file to a new folder under GOPATH/src. Also bring in the web.go-example file, renaming it to web.go. Then: **go run web.go docs.go**
 
 5. Enjoy it :-)
-
-
-
-
-
-

--- a/example/api.go
+++ b/example/api.go
@@ -4,6 +4,7 @@ package example
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/gocraft/web"
 	"github.com/yvasiyarov/swagger/example/subpackage"
 )

--- a/main.go
+++ b/main.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"flag"
+	"log"
+
+	"github.com/yvasiyarov/swagger/generator"
+)
+
+var apiPackage = flag.String("apiPackage", "", "The package that implements the API controllers, relative to $GOPATH/src")
+var mainApiFile = flag.String("mainApiFile", "", "The file that contains the general API annotations, relative to $GOPATH/src")
+var outputFormat = flag.String("format", "go", "Output format type for the generated files: "+generator.AVAILABLE_FORMATS)
+var outputSpec = flag.String("output", "", "Output (path) for the generated file(s)")
+var controllerClass = flag.String("controllerClass", "", "Speed up parsing by specifying which receiver objects have the controller methods")
+
+func main() {
+	flag.Parse()
+
+	if *mainApiFile == "" {
+		*mainApiFile = *apiPackage + "/main.go"
+	}
+
+	if *apiPackage == "" {
+		flag.PrintDefaults()
+		return
+	}
+
+	params := generator.Params{
+		ApiPackage:      *apiPackage,
+		MainApiFile:     *mainApiFile,
+		OutputFormat:    *outputFormat,
+		OutputSpec:      *outputSpec,
+		ControllerClass: *controllerClass,
+	}
+
+	err := generator.Run(params)
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -21,8 +21,8 @@ type Parser struct {
 	TypeDefinitions                   map[string]map[string]*ast.TypeSpec
 	PackagePathCache                  map[string]string
 	PackageImports                    map[string]map[string][]string
-	BasePath                          string
-	IsController                      func(*ast.FuncDecl) bool
+	BasePath, ControllerClass         string
+	IsController                      func(*ast.FuncDecl, string) bool
 	TypesImplementingMarshalInterface map[string]string
 }
 
@@ -407,7 +407,7 @@ func (parser *Parser) ParseApiDescription(packageName string) {
 			for _, astDescription := range astFile.Decls {
 				switch astDeclaration := astDescription.(type) {
 				case *ast.FuncDecl:
-					if parser.IsController(astDeclaration) {
+					if parser.IsController(astDeclaration, parser.ControllerClass) {
 						operation := NewOperation(parser, packageName)
 						if astDeclaration.Doc != nil && astDeclaration.Doc.List != nil {
 							for _, comment := range astDeclaration.Doc.List {
@@ -462,7 +462,7 @@ func (parser *Parser) ParseSubApiDescription(commentLine string) {
 
 func IsIgnoredPackage(packageName string) bool {
 	r, _ := regexp.Compile("appengine+")
-        return packageName == "C" || r.MatchString(packageName)
+	return packageName == "C" || r.MatchString(packageName)
 }
 
 func ParserFileFilter(info os.FileInfo) bool {


### PR DESCRIPTION
This is a documentation fix following the pull request https://github.com/yvasiyarov/swagger/pull/74. The `BasePath` flag doesn't exist anymore.