### PR TITLE
Allow top level @BasePath declarative comment

### DIFF
--- a/generator/generator.go
+++ b/generator/generator.go
@@ -110,7 +110,6 @@ func generateSwaggerUiFiles(parser *parser.Parser, outputSpec string) error {
 func InitParser(controllerClass string) *parser.Parser {
 	parser := parser.NewParser()
 
-	parser.BasePath = "{{.}}"
 	parser.ControllerClass = controllerClass
 	parser.IsController = IsController
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -54,7 +54,8 @@ func (parser *Parser) ParseGeneralApiInfo(mainApiFile string) {
 	if err != nil {
 		log.Fatalf("Can not parse general API information: %v\n", err)
 	}
-
+	
+	parser.Listing.BasePath = "{{.}}"
 	parser.Listing.SwaggerVersion = SwaggerVersion
 	if fileTree.Comments != nil {
 		for _, comment := range fileTree.Comments {
@@ -75,6 +76,8 @@ func (parser *Parser) ParseGeneralApiInfo(mainApiFile string) {
 					parser.Listing.Infos.LicenseUrl = strings.TrimSpace(commentLine[len(attribute):])
 				case "@license":
 					parser.Listing.Infos.License = strings.TrimSpace(commentLine[len(attribute):])
+				case "@basepath":
+					parser.Listing.BasePath = strings.TrimSpace(commentLine[len(attribute):])
 				}
 			}
 		}
@@ -191,7 +194,7 @@ func (parser *Parser) AddOperation(op *Operation) {
 		api.ApiVersion = parser.Listing.ApiVersion
 		api.SwaggerVersion = SwaggerVersion
 		api.ResourcePath = "/" + resource
-		api.BasePath = parser.BasePath
+		api.BasePath = parser.Listing.BasePath
 
 		parser.TopLevelApis[resource] = api
 	}

--- a/parser/structs.go
+++ b/parser/structs.go
@@ -18,7 +18,7 @@ var CommentIsEmptyError = errors.New("Comment is empty")
 type ResourceListing struct {
 	ApiVersion     string `json:"apiVersion"`
 	SwaggerVersion string `json:"swaggerVersion"`
-	//	BasePath       string     `json:"basePath"`
+	BasePath       string `json:"basePath,omitempty"`
 	Apis  []*ApiRef  `json:"apis"`
 	Infos Infomation `json:"info"`
 }


### PR DESCRIPTION
Allow top level @BasePath declarative comment (also applied to all subApis), default to '{{.}}' if omitted

Re: Issue #83 