### PR TITLE
Fix for issue #95, do not include default basePath on General API info

### DIFF
--- a/generator/generator.go
+++ b/generator/generator.go
@@ -12,8 +12,8 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/yvasiyarov/swagger/markup"
-	"github.com/yvasiyarov/swagger/parser"
+	"github.com/boonep/swagger/markup"
+	"github.com/boonep/swagger/parser"
 )
 
 const (
@@ -132,7 +132,6 @@ func Run(params Params) error {
 	if gopath == "" {
 		return errors.New("Please, set $GOPATH environment variable\n")
 	}
-
 	log.Println("Start parsing")
 
 	//Support gopaths with multiple directories

--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@ import (
 	"flag"
 	"log"
 
-	"github.com/yvasiyarov/swagger/generator"
+	"github.com/boonep/swagger/generator"
 )
 
 var apiPackage = flag.String("apiPackage", "", "The package that implements the API controllers, relative to $GOPATH/src")

--- a/markup/markup.go
+++ b/markup/markup.go
@@ -8,7 +8,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/yvasiyarov/swagger/parser"
+	"github.com/boonep/swagger/parser"
 )
 
 const (

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -55,7 +55,6 @@ func (parser *Parser) ParseGeneralApiInfo(mainApiFile string) {
 		log.Fatalf("Can not parse general API information: %v\n", err)
 	}
 	
-	parser.Listing.BasePath = "{{.}}"
 	parser.Listing.SwaggerVersion = SwaggerVersion
 	if fileTree.Comments != nil {
 		for _, comment := range fileTree.Comments {
@@ -194,7 +193,11 @@ func (parser *Parser) AddOperation(op *Operation) {
 		api.ApiVersion = parser.Listing.ApiVersion
 		api.SwaggerVersion = SwaggerVersion
 		api.ResourcePath = "/" + resource
-		api.BasePath = parser.Listing.BasePath
+		if parser.Listing.BasePath == "" {
+			api.BasePath = "{{.}}"
+		} else {
+			api.BasePath = parser.Listing.BasePath
+		}
 
 		parser.TopLevelApis[resource] = api
 	}


### PR DESCRIPTION
Depending on whether General API basePath should default to "{{.}}" or property shouldn't be present (as was prior to commit 3430d5b14cbeac355b58e11231eac3f702793af6).  This fix should revert to previous default behavior, while maintaining ability to set basePath via comments.
