### PR TITLE
Update operation.go

### DIFF
--- a/parser/operation.go
+++ b/parser/operation.go
@@ -145,7 +145,7 @@ func (operation *Operation) ParseParamComment(commentLine string) error {
 	swaggerParameter := Parameter{}
 	paramString := commentLine
 
-	re := regexp.MustCompile(`([-\w]+)[\s]+([\w]+)[\s]+([\w.]+)[\s]+([\w]+)[\s]+"([^"]+)"`)
+	re := regexp.MustCompile(`([-\w]+)[\s]+([\w]+)[\s]+([\S.]+)[\s]+([\w]+)[\s]+"([^"]+)"`)
 
 	if matches := re.FindStringSubmatch(paramString); len(matches) != 6 {
 		return fmt.Errorf("Can not parse param comment \"%s\", skipped.", paramString)


### PR DESCRIPTION
// @Param   service        body service-mgr.models.mservices.MserviceEntry     true        "service info"

My comment has a character "-" so I changed regex to fix error

 Can not parse comment for function: CreateMService, package: service-mgr/controllers/mservices, got error: Can not parse param comment "service        body service-mgr.models.mservices.MserviceEntry     true        "service info"", skipped.