### PR TITLE
Add functionalities to disable the "Table of Contents" and "Models" sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ The main difference between this tool and Beego is that this generator doesn't d
     * **-format**       - One of: go|swagger|asciidoc|markdown|confluence. Default is -format="go". See below.
     * **-output**       - Output specification. Default varies according to -format. See below.
     * **-controllerClass**  - Speed up parsing by specifying which receiver objects have the controller methods. The default is to search all methods. The argument can be a regular expression. For example, `-controllerClass="(Context|Controller)$"` means the receiver name must end in Context or Controller.
+    * **-contentsTable**       - Generate 'Table of Contents' section, default value is true, if set '-contentsTable=false' it will not generate the section.
+    * **-models**       - Generate 'Models' section, default value is true, if set '-models=false' it will not generate the section.
 
  [**You can Generate different formats** ](https://github.com/yvasiyarov/swagger/wiki/Generate-Different-Formats)
 

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -125,6 +125,7 @@ func InitParser(controllerClass, ignore string) *parser.Parser {
 
 type Params struct {
 	ApiPackage, MainApiFile, OutputFormat, OutputSpec, ControllerClass, Ignore string
+	ContentsTable bool
 }
 
 func Run(params Params) error {
@@ -169,13 +170,13 @@ func Run(params Params) error {
 		err = generateSwaggerDocs(parser, params.OutputSpec)
 		confirmMsg = "Doc file generated"
 	case "asciidoc":
-		err = markup.GenerateMarkup(parser, new(markup.MarkupAsciiDoc), &params.OutputSpec, ".adoc")
+		err = markup.GenerateMarkup(parser, new(markup.MarkupAsciiDoc), &params.OutputSpec, ".adoc", params.ContentsTable)
 		confirmMsg = "AsciiDoc file generated"
 	case "markdown":
-		err = markup.GenerateMarkup(parser, new(markup.MarkupMarkDown), &params.OutputSpec, ".md")
+		err = markup.GenerateMarkup(parser, new(markup.MarkupMarkDown), &params.OutputSpec, ".md", params.ContentsTable)
 		confirmMsg = "MarkDown file generated"
 	case "confluence":
-		err = markup.GenerateMarkup(parser, new(markup.MarkupConfluence), &params.OutputSpec, ".confluence")
+		err = markup.GenerateMarkup(parser, new(markup.MarkupConfluence), &params.OutputSpec, ".confluence", params.ContentsTable)
 		confirmMsg = "Confluence file generated"
 	case "swagger":
 		err = generateSwaggerUiFiles(parser, params.OutputSpec)

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -125,7 +125,7 @@ func InitParser(controllerClass, ignore string) *parser.Parser {
 
 type Params struct {
 	ApiPackage, MainApiFile, OutputFormat, OutputSpec, ControllerClass, Ignore string
-	ContentsTable bool
+	ContentsTable, Models bool
 }
 
 func Run(params Params) error {
@@ -170,13 +170,13 @@ func Run(params Params) error {
 		err = generateSwaggerDocs(parser, params.OutputSpec)
 		confirmMsg = "Doc file generated"
 	case "asciidoc":
-		err = markup.GenerateMarkup(parser, new(markup.MarkupAsciiDoc), &params.OutputSpec, ".adoc", params.ContentsTable)
+		err = markup.GenerateMarkup(parser, new(markup.MarkupAsciiDoc), &params.OutputSpec, ".adoc", params.ContentsTable, params.Models)
 		confirmMsg = "AsciiDoc file generated"
 	case "markdown":
-		err = markup.GenerateMarkup(parser, new(markup.MarkupMarkDown), &params.OutputSpec, ".md", params.ContentsTable)
+		err = markup.GenerateMarkup(parser, new(markup.MarkupMarkDown), &params.OutputSpec, ".md", params.ContentsTable, params.Models)
 		confirmMsg = "MarkDown file generated"
 	case "confluence":
-		err = markup.GenerateMarkup(parser, new(markup.MarkupConfluence), &params.OutputSpec, ".confluence", params.ContentsTable)
+		err = markup.GenerateMarkup(parser, new(markup.MarkupConfluence), &params.OutputSpec, ".confluence", params.ContentsTable, params.Models)
 		confirmMsg = "Confluence file generated"
 	case "swagger":
 		err = generateSwaggerUiFiles(parser, params.OutputSpec)

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ var outputFormat = flag.String("format", "go", "Output format type for the gener
 var outputSpec = flag.String("output", "", "Output (path) for the generated file(s)")
 var controllerClass = flag.String("controllerClass", "", "Speed up parsing by specifying which receiver objects have the controller methods")
 var ignore = flag.String("ignore", "^$", "Ignore packages that satisfy this match")
+var contentsTable = flag.Bool("contentsTable", true, "Generate the section Table of Contents")
 
 func main() {
 	flag.Parse()
@@ -33,6 +34,7 @@ func main() {
 		OutputSpec:      *outputSpec,
 		ControllerClass: *controllerClass,
 		Ignore:          *ignore,
+		ContentsTable:	 *contentsTable,
 	}
 
 	err := generator.Run(params)

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ var outputSpec = flag.String("output", "", "Output (path) for the generated file
 var controllerClass = flag.String("controllerClass", "", "Speed up parsing by specifying which receiver objects have the controller methods")
 var ignore = flag.String("ignore", "^$", "Ignore packages that satisfy this match")
 var contentsTable = flag.Bool("contentsTable", true, "Generate the section Table of Contents")
+var models = flag.Bool("models", true, "Generate the section models if any defined")
 
 func main() {
 	flag.Parse()
@@ -35,6 +36,7 @@ func main() {
 		ControllerClass: *controllerClass,
 		Ignore:          *ignore,
 		ContentsTable:	 *contentsTable,
+		Models:		 *models,
 	}
 
 	err := generator.Run(params)

--- a/markup/markup.go
+++ b/markup/markup.go
@@ -76,7 +76,9 @@ func GenerateMarkup(parser *parser.Parser, markup Markup, outputSpec *string, de
 		/***************************************************************
 		* Sub-API Specifications
 		***************************************************************/
-		buf.WriteString(markup.anchor(apiKey))
+		if tableContents {
+			buf.WriteString(markup.anchor(apiKey))
+		}
 		buf.WriteString(markup.sectionHeader(2, markup.colorSpan(apiKey, color_API_SECTION_HEADER_TEXT, color_NORMAL_BACKGROUND)))
 
 		buf.WriteString(markup.tableHeader(""))
@@ -113,7 +115,9 @@ func GenerateMarkup(parser *parser.Parser, markup Markup, outputSpec *string, de
 			for _, op := range subapi.Operations {
 				buf.WriteString("\n")
 				operationString := fmt.Sprintf("%s (%s)", strings.Replace(strings.Replace(subapi.Path, "{", "\\{", -1), "}", "\\}", -1), op.HttpMethod)
-				buf.WriteString(markup.anchor(op.Nickname))
+				if tableContents {
+					buf.WriteString(markup.anchor(op.Nickname))
+				}
 				buf.WriteString(markup.sectionHeader(4, markup.colorSpan("API: "+operationString, color_NORMAL_TEXT, operationColor(op.HttpMethod))))
 				buf.WriteString("\n\n" + op.Summary + "\n\n\n")
 
@@ -153,7 +157,9 @@ func GenerateMarkup(parser *parser.Parser, markup Markup, outputSpec *string, de
 
 		for _, modelKey := range alphabeticalKeysOfModels(apiDescription.Models) {
 			model := apiDescription.Models[modelKey]
-			buf.WriteString(markup.anchor(modelKey))
+			if tableContents {
+				buf.WriteString(markup.anchor(modelKey))
+			}
 			buf.WriteString(markup.sectionHeader(4, markup.colorSpan(shortModelName(modelKey), color_MODEL_TEXT, color_NORMAL_BACKGROUND)))
 			buf.WriteString(markup.tableHeader(""))
 			buf.WriteString(markup.tableHeaderRow("Field Name (alphabetical)", "Field Type", "Description"))

--- a/markup/markup.go
+++ b/markup/markup.go
@@ -37,7 +37,7 @@ type Markup interface {
 	colorSpan(content, foregroundColor, backgroundColor string) string
 }
 
-func GenerateMarkup(parser *parser.Parser, markup Markup, outputSpec *string, defaultFileExtension string) error {
+func GenerateMarkup(parser *parser.Parser, markup Markup, outputSpec *string, defaultFileExtension string, tableContents bool) error {
 	var filename string
 	if *outputSpec == "" {
 		filename = path.Join("./", "API") + defaultFileExtension
@@ -61,12 +61,14 @@ func GenerateMarkup(parser *parser.Parser, markup Markup, outputSpec *string, de
 	/***************************************************************
 	* Table of Contents (List of Sub-APIs)
 	***************************************************************/
-	buf.WriteString("Table of Contents\n\n")
-	subApiKeys, subApiKeyIndex := alphabeticalKeysOfSubApis(parser.Listing.Apis)
-	for _, subApiKey := range subApiKeys {
-		buf.WriteString(markup.numberedItem(1, markup.link(subApiKey, parser.Listing.Apis[subApiKeyIndex[subApiKey]].Description)))
+	if tableContents {
+		buf.WriteString("Table of Contents\n\n")
+		subApiKeys, subApiKeyIndex := alphabeticalKeysOfSubApis(parser.Listing.Apis)
+		for _, subApiKey := range subApiKeys {
+			buf.WriteString(markup.numberedItem(1, markup.link(subApiKey, parser.Listing.Apis[subApiKeyIndex[subApiKey]].Description)))
+		}
+		buf.WriteString("\n")
 	}
-	buf.WriteString("\n")
 
 	for _, apiKey := range alphabeticalKeysOfApiDeclaration(parser.TopLevelApis) {
 

--- a/markup/markup.go
+++ b/markup/markup.go
@@ -143,9 +143,11 @@ func GenerateMarkup(parser *parser.Parser, markup Markup, outputSpec *string, de
 		/***************************************************************
 		* Models
 		***************************************************************/
-		buf.WriteString("\n")
-		buf.WriteString(markup.sectionHeader(3, "Models"))
-		buf.WriteString("\n")
+		if len(apiDescription.Models) > 0 {
+			buf.WriteString("\n")
+			buf.WriteString(markup.sectionHeader(3, "Models"))
+			buf.WriteString("\n")
+		}
 
 		for _, modelKey := range alphabeticalKeysOfModels(apiDescription.Models) {
 			model := apiDescription.Models[modelKey]

--- a/markup/markup.go
+++ b/markup/markup.go
@@ -37,7 +37,7 @@ type Markup interface {
 	colorSpan(content, foregroundColor, backgroundColor string) string
 }
 
-func GenerateMarkup(parser *parser.Parser, markup Markup, outputSpec *string, defaultFileExtension string, tableContents bool) error {
+func GenerateMarkup(parser *parser.Parser, markup Markup, outputSpec *string, defaultFileExtension string, tableContents bool, models bool) error {
 	var filename string
 	if *outputSpec == "" {
 		filename = path.Join("./", "API") + defaultFileExtension
@@ -149,28 +149,26 @@ func GenerateMarkup(parser *parser.Parser, markup Markup, outputSpec *string, de
 		/***************************************************************
 		* Models
 		***************************************************************/
-		if len(apiDescription.Models) > 0 {
+		if len(apiDescription.Models) > 0 && models {
 			buf.WriteString("\n")
 			buf.WriteString(markup.sectionHeader(3, "Models"))
 			buf.WriteString("\n")
-		}
-
-		for _, modelKey := range alphabeticalKeysOfModels(apiDescription.Models) {
-			model := apiDescription.Models[modelKey]
-			if tableContents {
-				buf.WriteString(markup.anchor(modelKey))
+			for _, modelKey := range alphabeticalKeysOfModels(apiDescription.Models) {
+				model := apiDescription.Models[modelKey]
+				if tableContents {
+					buf.WriteString(markup.anchor(modelKey))
+				}
+				buf.WriteString(markup.sectionHeader(4, markup.colorSpan(shortModelName(modelKey), color_MODEL_TEXT, color_NORMAL_BACKGROUND)))
+				buf.WriteString(markup.tableHeader(""))
+				buf.WriteString(markup.tableHeaderRow("Field Name (alphabetical)", "Field Type", "Description"))
+				for _, fieldName := range alphabeticalKeysOfFields(model.Properties) {
+					fieldProps := model.Properties[fieldName]
+					buf.WriteString(markup.tableRow(fieldName, fieldProps.Type, fieldProps.Description))
+				}
+				buf.WriteString(markup.tableFooter())
 			}
-			buf.WriteString(markup.sectionHeader(4, markup.colorSpan(shortModelName(modelKey), color_MODEL_TEXT, color_NORMAL_BACKGROUND)))
-			buf.WriteString(markup.tableHeader(""))
-			buf.WriteString(markup.tableHeaderRow("Field Name (alphabetical)", "Field Type", "Description"))
-			for _, fieldName := range alphabeticalKeysOfFields(model.Properties) {
-				fieldProps := model.Properties[fieldName]
-				buf.WriteString(markup.tableRow(fieldName, fieldProps.Type, fieldProps.Description))
-			}
-			buf.WriteString(markup.tableFooter())
+			buf.WriteString("\n")
 		}
-		buf.WriteString("\n")
-
 	}
 
 	fd.WriteString(buf.String())


### PR DESCRIPTION
There are a couple of functions that might be added to have a bit more flexible tool, right now there are some sections which may be not required to be generated:

- Table of Contents
- Models

The previous defined sections are always generated but there might be the cases when users
don't want these sections to be in their output. We are adding the flexibility to the tool to be indicated if the sections are desired or not to be. The tool will keep its default behavior as now, but with this changes the users will be able specify the tool if they don't want these sections with the optional parameters:

`-contentsTable=false`
`-models=false`