### PR TITLE
gopkg format

### DIFF
--- a/example/api.go
+++ b/example/api.go
@@ -147,9 +147,9 @@ func InitRouter() *web.Router {
 		Middleware(web.LoggerMiddleware).
 		Middleware(web.ShowErrorsMiddleware).
 		Middleware(func(c *Context, rw web.ResponseWriter, req *web.Request, next web.NextMiddlewareFunc) {
-		resultJSON, _ := json.Marshal(c.response)
-		rw.Write(resultJSON)
-	}).
+			resultJSON, _ := json.Marshal(c.response)
+			rw.Write(resultJSON)
+		}).
 		Get("/testapi/get-string-by-int/{some_id}", (*Context).GetStringByInt).
 		Get("/testapi/get-struct-by-int/{some_id}", (*Context).GetStructByInt).
 		Get("/testapi/get-simple-array-by-string/{some_id}", (*Context).GetSimpleArrayByString).

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -78,12 +78,12 @@ func generateSwaggerDocs(parser *parser.Parser, outputSpec string, pkg bool) err
 
 	var doc string
 	if pkg {
-		doc := strings.Replace(generatedPkgTemplate, "{{resourceListing}}", "`"+string(parser.GetResourceListingJson())+"`", -1)
+		doc = strings.Replace(generatedPkgTemplate, "{{resourceListing}}", "`"+string(parser.GetResourceListingJson())+"`", -1)
 		doc = strings.Replace(doc, "{{apiDescriptions}}", "map[string]string{"+apiDescriptions.String()+"}", -1)
 		packageName := strings.Split(outputSpec, "/")
 		doc = strings.Replace(doc, "{{packageName}}", packageName[len(packageName)-1], -1)
 	} else {
-		doc := strings.Replace(generatedFileTemplate, "{{resourceListing}}", "`"+string(parser.GetResourceListingJson())+"`", -1)
+		doc = strings.Replace(generatedFileTemplate, "{{resourceListing}}", "`"+string(parser.GetResourceListingJson())+"`", -1)
 		doc = strings.Replace(doc, "{{apiDescriptions}}", "map[string]string{"+apiDescriptions.String()+"}", -1)
 	}
 

--- a/main.go
+++ b/main.go
@@ -35,8 +35,8 @@ func main() {
 		OutputSpec:      *outputSpec,
 		ControllerClass: *controllerClass,
 		Ignore:          *ignore,
-		ContentsTable:	 *contentsTable,
-		Models:		 *models,
+		ContentsTable:   *contentsTable,
+		Models:          *models,
 	}
 
 	err := generator.Run(params)

--- a/parser/structs.go
+++ b/parser/structs.go
@@ -16,11 +16,11 @@ const (
 var CommentIsEmptyError = errors.New("Comment is empty")
 
 type ResourceListing struct {
-	ApiVersion     string `json:"apiVersion"`
-	SwaggerVersion string `json:"swaggerVersion"`
-	BasePath       string `json:"basePath,omitempty"`
-	Apis  []*ApiRef  `json:"apis"`
-	Infos Infomation `json:"info"`
+	ApiVersion     string     `json:"apiVersion"`
+	SwaggerVersion string     `json:"swaggerVersion"`
+	BasePath       string     `json:"basePath,omitempty"`
+	Apis           []*ApiRef  `json:"apis"`
+	Infos          Infomation `json:"info"`
 }
 
 type ApiRef struct {


### PR DESCRIPTION
Helper format for when you want to create a package instead of a main file. Useful if you run your server from a package instead of main.