### PR TITLE
Vendoring: provide vendoring and avoid "_" (hidden dirs) to inspect the imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ The main difference between this tool and Beego is that this generator doesn't d
     * **-controllerClass**  - Speed up parsing by specifying which receiver objects have the controller methods. The default is to search all methods. The argument can be a regular expression. For example, `-controllerClass="(Context|Controller)$"` means the receiver name must end in Context or Controller.
     * **-contentsTable**       - Generate 'Table of Contents' section, default value is true, if set '-contentsTable=false' it will not generate the section.
     * **-models**       - Generate 'Models' section, default value is true, if set '-models=false' it will not generate the section.
+    * **-vendoringPath** - Specify the vendoring directory instead of using current working directory
 
  [**You can Generate different formats** ](https://github.com/yvasiyarov/swagger/wiki/Generate-Different-Formats)
 

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -140,7 +140,7 @@ func InitParser(controllerClass, ignore string) *parser.Parser {
 }
 
 type Params struct {
-	ApiPackage, MainApiFile, OutputFormat, OutputSpec, ControllerClass, Ignore string
+	ApiPackage, MainApiFile, OutputFormat, OutputSpec, ControllerClass, Ignore, VendoringPath string
 	ContentsTable, Models                                                      bool
 }
 
@@ -175,7 +175,7 @@ func Run(params Params) error {
 		}
 	}
 
-	parser.ParseApi(params.ApiPackage)
+	parser.ParseApi(params.ApiPackage, params.VendoringPath)
 	log.Println("Finish parsing")
 
 	var err error

--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ var controllerClass = flag.String("controllerClass", "", "Speed up parsing by sp
 var ignore = flag.String("ignore", "^$", "Ignore packages that satisfy this match")
 var contentsTable = flag.Bool("contentsTable", true, "Generate the section Table of Contents")
 var models = flag.Bool("models", true, "Generate the section models if any defined")
+var vendoringPath = flag.String("vendoringPath", "", "Directory of vendoring if used")
 
 func main() {
 	flag.Parse()
@@ -37,6 +38,7 @@ func main() {
 		Ignore:          *ignore,
 		ContentsTable:   *contentsTable,
 		Models:          *models,
+		VendoringPath:	 *vendoringPath,
 	}
 
 	err := generator.Run(params)

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -257,7 +257,8 @@ func (parser *Parser) ScanPackages(packages []string) []string {
 			pkgRealPath := parser.GetRealPackagePath(packageName)
 			// Then walk
 			var walker filepath.WalkFunc = func(path string, info os.FileInfo, err error) error {
-				if info.IsDir() {
+				// avoid listing hidden directories with initial "_" names and vendor dir
+				if info.IsDir() && !strings.Contains(path, "/_") && !strings.Contains(path, "/vendor") {
 					if idx := strings.Index(path, packageName); idx != -1 {
 						pack := path[idx:]
 						if v, ok := existsPackages[pack]; !ok || v == false {


### PR DESCRIPTION
This PR is focused on Vendoring.

- Add flag "vendoringPath" to specify if the vendor directory is in a different directory (documented too)
- Ensure the tool is not looking into hidden directories when their names start with "_" and vendor dir when inspecting for imports