### PR TITLE
remove redundant lookup

### DIFF
--- a/generator/generator.go
+++ b/generator/generator.go
@@ -164,6 +164,7 @@ func Run(params Params) error {
 		if _, err := os.Stat(apifile); err == nil {
 			parser.ParseGeneralApiInfo(apifile)
 			found = true
+			break // file found, exit the loop
 		}
 	}
 	if found == false {


### PR DESCRIPTION
- Once api file has been found, no need to lookup in more paths, just exit