### PR TITLE
Add wildcard support to api package paths

### DIFF
--- a/parser/package_path_expander.go
+++ b/parser/package_path_expander.go
@@ -1,0 +1,61 @@
+package parser
+
+import (
+	"os"
+	"strings"
+
+	"github.com/spf13/afero"
+)
+
+const MaxLevelInfinity = -1
+
+type packagePathExpander struct {
+	maxLevels int
+
+	relativePackagePaths []string
+}
+
+func (p *packagePathExpander) appendRelPath(relPath string) {
+	relPath = strings.Replace(relPath, "\\", "/", MaxLevelInfinity)
+	p.relativePackagePaths = append(p.relativePackagePaths, relPath)
+}
+
+func (p *packagePathExpander) calcLevel(relPath string) (level int) {
+	relPath = strings.Replace(relPath, "\\", "/", MaxLevelInfinity)
+	relPath = strings.Trim(relPath, "/")
+	level = len(strings.Split(relPath, "/"))
+	return
+}
+
+func (p *packagePathExpander) WalkDir(baseFS afero.Fs) error {
+	return afero.Walk(baseFS, "", func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if !info.IsDir() {
+			return nil
+		}
+		if path == "" {
+			p.appendRelPath(path)
+			//Base path was already added at the begging of Walk
+			return nil
+		}
+
+		level := p.calcLevel(path)
+		if p.maxLevels != MaxLevelInfinity && level > p.maxLevels {
+			return nil
+		}
+
+		p.appendRelPath(path)
+		return nil
+	})
+}
+
+func (p *packagePathExpander) PrefixedRelativePaths(prefix string) (paths []string) {
+	paths = []string{}
+	for _, path := range p.relativePackagePaths {
+		paths = append(paths, strings.TrimRight(prefix, "/")+"/"+strings.TrimLeft(path, "/"))
+	}
+	return
+}

--- a/parser/package_path_expander_test.go
+++ b/parser/package_path_expander_test.go
@@ -1,0 +1,104 @@
+package parser
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/spf13/afero"
+)
+
+func incCnt(cnt *int) int {
+	*cnt++
+	return *cnt
+}
+
+func Test_packagePathExpander_calcLevel(t *testing.T) {
+	var (
+		cnt          int
+		pathExpander = &packagePathExpander{}
+	)
+
+	type args struct {
+		relPath string
+	}
+	tests := []struct {
+		name      string
+		p         *packagePathExpander
+		args      args
+		wantLevel int
+	}{
+		{fmt.Sprintf("Case %d", incCnt(&cnt)), pathExpander, args{"path/"}, 1},
+		{fmt.Sprintf("Case %d", incCnt(&cnt)), pathExpander, args{"/path/"}, 1},
+		{fmt.Sprintf("Case %d", incCnt(&cnt)), pathExpander, args{"/path"}, 1},
+		{fmt.Sprintf("Case %d", incCnt(&cnt)), pathExpander, args{"path"}, 1},
+		{fmt.Sprintf("Case %d", incCnt(&cnt)), pathExpander, args{"p"}, 1},
+		{fmt.Sprintf("Case %d", incCnt(&cnt)), pathExpander, args{"path/one"}, 2},
+		{fmt.Sprintf("Case %d", incCnt(&cnt)), pathExpander, args{"path/one/"}, 2},
+		{fmt.Sprintf("Case %d", incCnt(&cnt)), pathExpander, args{"/path/one"}, 2},
+		{fmt.Sprintf("Case %d", incCnt(&cnt)), pathExpander, args{"/path/one/"}, 2},
+	}
+	for _, tt := range tests {
+		if gotLevel := tt.p.calcLevel(tt.args.relPath); gotLevel != tt.wantLevel {
+			t.Errorf("%q. packagePathExpander.calcLevel() = %v, want %v", tt.name, gotLevel, tt.wantLevel)
+		}
+	}
+}
+
+func createFSTree(t *testing.T, fs afero.Fs, paths []string) {
+	for _, path := range paths {
+		if err := fs.MkdirAll(path, 0700); err != nil {
+			t.Fatal(err.Error())
+		}
+	}
+}
+
+func Test_packagePathExpander_WalkDir(t *testing.T) {
+	var (
+		cnt    int
+		baseFS = afero.NewMemMapFs()
+	)
+
+	createFSTree(t, baseFS, []string{
+		"d1/d11/d111",
+		"d2",
+		"d2/d21/d121",
+	})
+
+	type args struct {
+		baseFS afero.Fs
+	}
+	tests := []struct {
+		name                     string
+		p                        *packagePathExpander
+		args                     args
+		wantErr                  bool
+		wantRelativePackagePaths []string
+	}{
+		{fmt.Sprintf("Case %d", incCnt(&cnt)), &packagePathExpander{0, nil}, args{baseFS}, false, []string{""}},
+		{fmt.Sprintf("Case %d", incCnt(&cnt)), &packagePathExpander{1, nil}, args{baseFS}, false, []string{"", "d1", "d2"}},
+		{fmt.Sprintf("Case %d", incCnt(&cnt)), &packagePathExpander{2, nil}, args{baseFS}, false, []string{"", "d1", "d1/d11", "d2", "d2/d21"}},
+		{fmt.Sprintf("Case %d", incCnt(&cnt)), &packagePathExpander{3, nil}, args{baseFS}, false, []string{"", "d1", "d1/d11", "d1/d11/d111", "d2", "d2/d21", "d2/d21/d121"}},
+		{fmt.Sprintf("Case %d", incCnt(&cnt)), &packagePathExpander{4, nil}, args{baseFS}, false, []string{"", "d1", "d1/d11", "d1/d11/d111", "d2", "d2/d21", "d2/d21/d121"}},
+		{fmt.Sprintf("Case %d", incCnt(&cnt)), &packagePathExpander{MaxLevelInfinity, nil}, args{baseFS}, false, []string{"", "d1", "d1/d11", "d1/d11/d111", "d2", "d2/d21", "d2/d21/d121"}},
+	}
+	for _, tt := range tests {
+		if err := tt.p.WalkDir(tt.args.baseFS); (err != nil) != tt.wantErr {
+			t.Errorf("%q. packagePathExpander.WalkDir() error = %v, wantErr %v", tt.name, err, tt.wantErr)
+		}
+		if len(tt.wantRelativePackagePaths) != len(tt.p.relativePackagePaths) {
+			t.Errorf("%q. packagePathExpander.WalkDir() len(relativePackagePaths) = %v, want %v", tt.name, len(tt.p.relativePackagePaths), len(tt.wantRelativePackagePaths))
+		}
+		for _, wantRel := range tt.wantRelativePackagePaths {
+			containsWant := false
+			for _, rel := range tt.p.relativePackagePaths {
+				if rel == wantRel {
+					containsWant = true
+					break
+				}
+			}
+			if !containsWant {
+				t.Errorf("%q. packagePathExpander.WalkDir() relativePackagePaths does not contain %v. Only contained: %v", tt.name, wantRel, tt.p.relativePackagePaths)
+			}
+		}
+	}
+}


### PR DESCRIPTION
This pull request will add support for using `/**` and `/*` at the end of packages passed to the `apiPackage` cli flag. Where `/**` means transverse into all levels and `/*` means to just transverse into the direct sub-directories.

- `swagger -apiPackage="my_cool_api/controllers/**"` -mainApiFile="my_cool_api/web/main.go"