### PR TITLE
vendor update, logging, minor refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,18 +13,11 @@ This is a utility for automatically generating API documentation from annotation
 This tool was inspired by [Beego](http://beego.me/docs/advantage/docs.md), and follows the same annotation standards set by Beego.
 The main difference between this tool and Beego is that this generator doesn't depend on the Beego framework. You can use any framework to implement your API (or don't use a framework at all). You just add declarative comments to your API controllers, then run this generator and your documentation is ready! For an example of what such documentation looks like when presented via Swagger UI, see the Swagger [pet store example](http://petstore.swagger.wordnik.com/).
 
-<br>
+This tool focuses on _documentation generation_ as opposed to _client_ generation. If that is all you need, it will be significantly easier to integrate this tool into your existing codebase/workflow as opposed to [goswagger](https://goswagger.io/). One significant advantage of this tool is that it allows you to easily reference objects that are outside of your package.
 
+_This tool currently generates Swagger 1.x spec files -- there are plans to update the tool to support Swagger 2.x at some point._
 
-#### Project Status : [Alpha](https://github.com/yvasiyarov/swagger/wiki/Declarative-Comments-Format)
-#### Declarative Comments Format : [Read more ](https://github.com/yvasiyarov/swagger/wiki/Declarative-Comments-Format)
-#### Technical Notes : [Read More ](https://github.com/yvasiyarov/swagger/wiki/Technical-Notes)
-#### Known Limitations : [Read More ](https://github.com/yvasiyarov/swagger/wiki/Known-Limitations)
-
-<br>
-
-#### Quick Start Guide
-
+### Quick Start Guide
 
 1. Add comments to your API source code, [see Declarative Comments Format ](https://github.com/yvasiyarov/swagger/wiki/Declarative-Comments-Format)
 
@@ -36,28 +29,42 @@ The main difference between this tool and Beego is that this generator doesn't d
     This will create a binary in your $GOPATH/bin folder called swagger (Mac/Unix) or swagger.exe (Windows).
 
 4. Run the Swagger generator.
-    Be in the folder with your annotated API source code and run the swagger binary:
+    Make sure to specify the full package name and an optional entry point (if the entry point isn't `$pkg/main.go`).
 
-    `./$GOPATH/bin/swagger -apiPackage="my_cool_api" -mainApiFile="my_cool_api/web/main.go"`
-
-Command line switches are:
----
+    Example:
     
+    ```
+    $ pwd
+    /Users/dselans/Code/go/src/github.com/yvasiyarov/swagger
+    $ ./$GOPATH/bin/swagger -apiPackage="github.com/yvasiyarov/swagger/example" -mainApiFile=example/web/main.go -output=./API.md -format=markdown
+    ```
+    
+### Command Line Flags
 |  Switch  |  Description   |
 |------------------|---------------------------|    
-| **apiPackage**  | package with API controllers implementation |
-| **mainApiFile** | main API file. We will look for "General API info" in this file. If the mainApiFile command-line switch is left blank, then main.go is assumed (in the location specified by apiPackage). | 
-| **format**      | One of: go\|swagger\|asciidoc\|markdown\|confluence. Default is -format="go". See below. |
-| **output**     | Output specification. Default varies according to -format. See below.|
+| **-apiPackage**  | Package with API controllers implementation |
+| **-mainApiFile** | Main API file. This file is used for generating the "General API Info" bits. If `-mainApiFile` is not specified, then `$apiPackage/main.go` is assumed. | 
+| **-format**      | One of: `go|swagger|asciidoc|markdown|confluence`. Default is `-format="go"`. See See [docs](https://github.com/yvasiyarov/swagger/wiki/Generate-Different-Formats). |
+| **-output**     | Output specification. Default varies according to -format. See [docs](https://github.com/yvasiyarov/swagger/wiki/Generate-Different-Formats). |
 | **controllerClass**  | Speed up parsing by specifying which receiver objects have the controller methods. The default is to search all methods. The argument can be a regular expression. For example, `-controllerClass="(Context|Controller)$"` means the receiver name must end in Context or Controller. |
-| **contentsTable**     | Generate 'Table of Contents' section, default value is true, if set '-contentsTable=false' it will not generate the section. |
-| **models**       | Generate 'Models' section, default value is true, if set '-models=false' it will not generate the section. |
-| **vendoringPath** | Specify the vendoring directory instead of using current working directory |
+| **contentsTable**     | Whether to generate Table of Contents; default: `true`. |
+| **models**       | Generate 'Models' section; default `true`. |
+| **vendoringPath** | Override default vendor directory (eg. `$CWD/vendor` and `$GOPATH/src/$apiPackage/vendor`) |
+| **disableVendoring** | Disable vendor usage altogether | 
+| **enableDebug** | Enable debug log output |
 
+### Note on Swagger-UI
 
- [**You can Generate different formats** ](https://github.com/yvasiyarov/swagger/wiki/Generate-Different-Formats)
+To run the generated swagger UI (assuming you used -format="go"), copy/move the generated docs.go file to a new folder under GOPATH/src. Also bring in the web.go-example file, renaming it to web.go. Then: `go run web.go docs.go`
 
+### Additional Documentation
 
-5. To run the generated swagger UI (assuming you used -format="go"), copy/move the generated docs.go file to a new folder under GOPATH/src. Also bring in the web.go-example file, renaming it to web.go. Then: **go run web.go docs.go**
+**Project Status** : [Alpha](https://github.com/yvasiyarov/swagger/wiki/Declarative-Comments-Format)
 
-6. Enjoy it :-)
+**Declarative Comments Format** : [Read more ](https://github.com/yvasiyarov/swagger/wiki/Declarative-Comments-Format)
+
+**Technical Notes** : [Read More](https://github.com/yvasiyarov/swagger/wiki/Technical-Notes)
+
+**Known Limitations** : [Read More](https://github.com/yvasiyarov/swagger/wiki/Known-Limitations)
+    
+ **Generating Different Format Docs**: [Read More](https://github.com/yvasiyarov/swagger/wiki/Generate-Different-Formats)

--- a/main.go
+++ b/main.go
@@ -2,8 +2,9 @@ package main
 
 import (
 	"flag"
-	"log"
+	"strings"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/yvasiyarov/swagger/generator"
 )
 
@@ -15,13 +16,23 @@ var controllerClass = flag.String("controllerClass", "", "Speed up parsing by sp
 var ignore = flag.String("ignore", "^$", "Ignore packages that satisfy this match")
 var contentsTable = flag.Bool("contentsTable", true, "Generate the section Table of Contents")
 var models = flag.Bool("models", true, "Generate the section models if any defined")
-var vendoringPath = flag.String("vendoringPath", "", "Directory of vendoring if used")
+var vendoringPath = flag.String("vendoringPath", "", "Override default vendor directory")
+var disableVendoring = flag.Bool("disableVendoring", false, "Disable vendor dir usage")
+var enableDebug = flag.Bool("enableDebug", false, "Enable debug log output")
 
-func main() {
+func init() {
 	flag.Parse()
 
+	if *enableDebug {
+		log.SetLevel(log.DebugLevel)
+		log.Info("Debug logging enabled")
+	}
+}
+
+func main() {
 	if *mainApiFile == "" {
 		*mainApiFile = *apiPackage + "/main.go"
+		log.Debugf("Using '%v' as main API file", *mainApiFile)
 	}
 
 	if *apiPackage == "" {
@@ -29,16 +40,20 @@ func main() {
 		return
 	}
 
+	// Get rid of trailing /
+	*vendoringPath = strings.TrimSuffix(*vendoringPath, "/")
+
 	params := generator.Params{
-		ApiPackage:      *apiPackage,
-		MainApiFile:     *mainApiFile,
-		OutputFormat:    *outputFormat,
-		OutputSpec:      *outputSpec,
-		ControllerClass: *controllerClass,
-		Ignore:          *ignore,
-		ContentsTable:   *contentsTable,
-		Models:          *models,
-		VendoringPath:	 *vendoringPath,
+		ApiPackage:       *apiPackage,
+		MainApiFile:      *mainApiFile,
+		OutputFormat:     *outputFormat,
+		OutputSpec:       *outputSpec,
+		ControllerClass:  *controllerClass,
+		Ignore:           *ignore,
+		ContentsTable:    *contentsTable,
+		Models:           *models,
+		VendoringPath:    *vendoringPath,
+		DisableVendoring: *disableVendoring,
 	}
 
 	err := generator.Run(params)

--- a/parser/api_declaration_test.go
+++ b/parser/api_declaration_test.go
@@ -1,10 +1,11 @@
 package parser_test
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"github.com/yvasiyarov/swagger/parser"
-	"testing"
 )
 
 type ApiDeclarationSuite struct {
@@ -16,7 +17,9 @@ type ApiDeclarationSuite struct {
 }
 
 func (suite *ApiDeclarationSuite) SetupSuite() {
-	suite.parser = parser.NewParser()
+	var err error
+	suite.parser, err = parser.NewParser(apiPackages, "", "^$", "", false)
+	assert.NoError(suite.T(), err, "Unable to complete suite initialization")
 	suite.operation = parser.NewOperation(suite.parser, "test")
 	suite.operation2 = parser.NewOperation(suite.parser, "test")
 	suite.operation3 = parser.NewOperation(suite.parser, "test")

--- a/parser/model.go
+++ b/parser/model.go
@@ -3,7 +3,6 @@ package parser
 import (
 	"fmt"
 	"go/ast"
-	"log"
 	"reflect"
 	"regexp"
 	"strings"

--- a/parser/model_test.go
+++ b/parser/model_test.go
@@ -1,12 +1,13 @@
 package parser_test
 
 import (
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/suite"
-	"github.com/yvasiyarov/swagger/parser"
 	"go/ast"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"github.com/yvasiyarov/swagger/parser"
 )
 
 type ModelSuite struct {
@@ -21,7 +22,11 @@ const ExamplePackageName = "github.com/yvasiyarov/swagger/example"
 
 func (suite *ModelSuite) SetupSuite() {
 	if initialisedParser == nil {
-		initialisedParser = parser.NewParser()
+		var err error
+
+		initialisedParser, err = parser.NewParser(apiPackages, "", "^$", "", false)
+		assert.NoError(suite.T(), err, "Unable to complete suite initialization")
+
 		initialisedParser.ParseTypeDefinitions(ExamplePackageName)
 	}
 	suite.parser = initialisedParser

--- a/parser/operation_test.go
+++ b/parser/operation_test.go
@@ -15,7 +15,9 @@ type OperationSuite struct {
 }
 
 func (suite *OperationSuite) SetupSuite() {
-	suite.parser = parser.NewParser()
+	var err error
+	suite.parser, err = parser.NewParser(apiPackages, "", "^$", "", false)
+	assert.NoError(suite.T(), err, "Unable to complete suite initialization")
 }
 
 func (suite *OperationSuite) TestNewApi() {

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -2,15 +2,16 @@ package parser_test
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/suite"
-	"github.com/yvasiyarov/swagger/parser"
 	"go/ast"
-	//	"log"
+
 	"os"
 	"path"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"github.com/yvasiyarov/swagger/parser"
 )
 
 type ParserSuite struct {
@@ -31,10 +32,14 @@ func IsController(funcDeclaration *ast.FuncDecl, controllerClass string) bool {
 
 var initialisedParser2 *parser.Parser
 var exampleBasePath = "http://127.0.0.1:3000/"
+var apiPackages = "github.com/yvasiyarov/swagger/example"
 
 func (suite *ParserSuite) SetupSuite() {
 	if initialisedParser2 == nil {
-		initialisedParser2 = parser.NewParser()
+		var err error
+
+		initialisedParser2, err = parser.NewParser(apiPackages, "", "^$", "", false)
+		assert.NoError(suite.T(), err, "Unable to complete suite initialization")
 
 		initialisedParser2.BasePath = exampleBasePath
 		initialisedParser2.IsController = IsController
@@ -45,7 +50,7 @@ func (suite *ParserSuite) SetupSuite() {
 		}
 
 		initialisedParser2.ParseGeneralApiInfo(path.Join(gopath, "src", "github.com/yvasiyarov/swagger/example/web/main.go"))
-		initialisedParser2.ParseApi("github.com/yvasiyarov/swagger/example", "")
+		initialisedParser2.ParseApi()
 	}
 	suite.parser = initialisedParser2
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,0 +1,33 @@
+package utils
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+func StringSliceContains(stringSlice []string, data string) bool {
+	for _, v := range stringSlice {
+		if v == data {
+			return true
+		}
+	}
+
+	return false
+}
+
+// return gopath, goroot, err
+func GetGoVars() (string, string, error) {
+	gopath := os.Getenv("GOPATH")
+	if gopath == "" {
+		return "", "", errors.New("Please set the $GOPATH environment variable")
+	}
+
+	goroot := filepath.Clean(runtime.GOROOT())
+	if goroot == "" {
+		return "", "", errors.New("Please set $GOROOT environment variable")
+	}
+
+	return gopath, goroot, nil
+}


### PR DESCRIPTION
- usage of vendor dirs enabled by default
- no longer need to specify a specific vendor dir
- can run tool from outside the target dir
- added logrus for logging + `enableDebug`
- moved `InitParser()` logic to `NewParser()`
- updated tests accordingly
- added helper `utils` lib (w/ `StringSliceContains()` and `GetGoVars()`)
- performance improvements (no longer scanning `.git` dirs and their subcontents; no longer looking for the main api package under vendor).